### PR TITLE
T26 Settings Panel

### DIFF
--- a/OFFEN.md
+++ b/OFFEN.md
@@ -30,7 +30,7 @@ Format: - [ ] ID (Phase) Titel :: Ziel :: Akzeptanz
 - [x] T23 (P1) Drag&Drop Modulreihenfolge speichern
 - [x] T24 (P1) Backup Auto-Rotation
 - [x] T25 (P1) Fehlerdialog UI (Benutzertext + Details)
-- [ ] T26 (P1) Settings Panel (Theme, FontScale)
+- [x] T26 (P1) Settings Panel (Theme, FontScale)
 - [ ] T27 (P1) EventBus implementieren
 - [ ] T28 (P1) Stats sammeln (module.open)
 - [ ] T29 (P1) Reset auf Werkzustand

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 from PySide6.QtGui import QKeySequence, QShortcut
+from modultool.settings_panel import SettingsDialog
 
 from modultool.logger import logger
 from modultool.theme_loader import apply_theme
@@ -28,6 +29,7 @@ class MainWindow(QMainWindow):
         self._module_maximized = False
         QShortcut(QKeySequence("F6"), self, activated=self.toggle_theme)
         QShortcut(QKeySequence("F7"), self, activated=self.toggle_maximize)
+        QShortcut(QKeySequence("F8"), self, activated=self.open_settings)
 
         central = QWidget()
         layout = QHBoxLayout(central)
@@ -79,6 +81,15 @@ class MainWindow(QMainWindow):
         else:
             self.showMaximized()
         self._module_maximized = not self._module_maximized
+
+    def open_settings(self) -> None:
+        """Open settings dialog to change theme and font size."""
+        app = QApplication.instance()
+        if not app:
+            return
+        dialog = SettingsDialog(app, self.current_theme, self)
+        if dialog.exec() == dialog.Accepted:
+            self.current_theme = dialog.theme_combo.currentText()
 
 
 def main() -> int:

--- a/erledigt.txt
+++ b/erledigt.txt
@@ -23,3 +23,4 @@ T22 Maximieren/Restore Modul :: 2025-07-21
 T23 Drag&Drop Modulreihenfolge speichern :: 2025-07-21
 T24 Backup Auto-Rotation :: 2025-07-21
 T25 Fehlerdialog UI :: 2025-07-21
+T26 Settings Panel :: 2025-07-21

--- a/modultool/settings_panel.py
+++ b/modultool/settings_panel.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QComboBox, QSpinBox, QDialogButtonBox, QApplication
+from PySide6.QtGui import QFont
+
+from .theme_loader import apply_theme
+
+
+class SettingsDialog(QDialog):
+    """Simple settings panel for theme and font size."""
+
+    def __init__(self, app: QApplication, current_theme: str, parent=None) -> None:
+        super().__init__(parent)
+        self.app = app
+        self.setWindowTitle("Einstellungen")
+
+        layout = QVBoxLayout(self)
+
+        layout.addWidget(QLabel("Theme"))
+        self.theme_combo = QComboBox()
+        self.theme_combo.addItems(["dark", "highcontrast"])
+        self.theme_combo.setCurrentText(current_theme)
+        layout.addWidget(self.theme_combo)
+
+        layout.addWidget(QLabel("Schriftgröße"))
+        self.font_spin = QSpinBox()
+        self.font_spin.setRange(8, 24)
+        self.font_spin.setValue(app.font().pointSize())
+        layout.addWidget(self.font_spin)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.apply_settings)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def apply_settings(self) -> None:
+        apply_theme(self.app, self.theme_combo.currentText())
+        font = QFont(self.app.font())
+        font.setPointSize(self.font_spin.value())
+        self.app.setFont(font)
+        self.accept()

--- a/tests/test_settings_panel.py
+++ b/tests/test_settings_panel.py
@@ -1,0 +1,26 @@
+import os
+from PySide6.QtWidgets import QApplication
+
+from modultool import config
+from modultool.settings_panel import SettingsDialog
+
+
+def test_settings_dialog_applies_changes(tmp_path, monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    theme_dir = tmp_path / "themes"
+    theme_dir.mkdir()
+    (theme_dir / "dark.qss").write_text("QWidget { color: #111; }", encoding="utf-8")
+    (theme_dir / "highcontrast.qss").write_text(
+        "QWidget { color: #ff0; }", encoding="utf-8"
+    )
+
+    monkeypatch.setattr(config, "get_theme_dir", lambda: theme_dir)
+    app = QApplication.instance() or QApplication([])
+    dialog = SettingsDialog(app, "dark")
+    dialog.theme_combo.setCurrentText("highcontrast")
+    dialog.font_spin.setValue(app.font().pointSize() + 1)
+    dialog.apply_settings()
+
+    assert "#ff0" in app.styleSheet()
+    assert app.font().pointSize() == dialog.font_spin.value()
+    app.quit()

--- a/todo.txt
+++ b/todo.txt
@@ -38,7 +38,7 @@ Weitere Punkte stehen in der Datei OFFEN.md.
 - [x] T23 Drag&Drop Modulreihenfolge speichern
 - [x] T24 Backup Auto-Rotation
 - [x] T25 Fehlerdialog UI (Benutzertext + Details)
-- [ ] T26 Settings Panel (Theme, FontScale)
+- [x] T26 Settings Panel (Theme, FontScale)
 - [ ] T27 EventBus implementieren
 - [ ] T28 Stats sammeln (module.open)
 - [ ] T29 Reset auf Werkzustand


### PR DESCRIPTION
## Summary
- add a small `SettingsDialog` for theme & font size
- hook F8 shortcut in `MainWindow` to open settings dialog
- mark task T26 done in `OFFEN.md` and `todo.txt`
- record T26 in `erledigt.txt`
- test the dialog with new unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ddf8387988325b66ff8773b62b5c3