### PR TITLE
T27 EventBus

### DIFF
--- a/OFFEN.md
+++ b/OFFEN.md
@@ -31,7 +31,7 @@ Format: - [ ] ID (Phase) Titel :: Ziel :: Akzeptanz
 - [x] T24 (P1) Backup Auto-Rotation
 - [x] T25 (P1) Fehlerdialog UI (Benutzertext + Details)
 - [x] T26 (P1) Settings Panel (Theme, FontScale)
-- [ ] T27 (P1) EventBus implementieren
+- [x] T27 (P1) EventBus implementieren
 - [ ] T28 (P1) Stats sammeln (module.open)
 - [ ] T29 (P1) Reset auf Werkzustand
 - [ ] T30 (P1) Selfcheck periodisch

--- a/erledigt.txt
+++ b/erledigt.txt
@@ -24,3 +24,4 @@ T23 Drag&Drop Modulreihenfolge speichern :: 2025-07-21
 T24 Backup Auto-Rotation :: 2025-07-21
 T25 Fehlerdialog UI :: 2025-07-21
 T26 Settings Panel :: 2025-07-21
+T27 EventBus implementiert :: 2025-07-21

--- a/modultool/__init__.py
+++ b/modultool/__init__.py
@@ -2,11 +2,18 @@ from .logger import logger
 from .selfcheck import run_selfcheck
 from .help_engine import register_help
 from .error_dialog import create_error_dialog
+from .event_bus import event_bus
 
 run_selfcheck()
 
-__all__ = ["logger", "run_selfcheck", "register_help", "create_error_dialog"]
+__all__ = [
+    "logger",
+    "run_selfcheck",
+    "register_help",
+    "create_error_dialog",
+    "event_bus",
+]
 
 run_selfcheck()
 
-__all__ = ["logger", "run_selfcheck", "register_help"]
+__all__ = ["logger", "run_selfcheck", "register_help", "event_bus"]

--- a/modultool/event_bus.py
+++ b/modultool/event_bus.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+from typing import Any
+
+
+class EventBus:
+    """Simple publish/subscribe event system."""
+
+    def __init__(self) -> None:
+        self._subscribers: dict[str, list[Callable[..., Any]]] = defaultdict(list)
+
+    def subscribe(self, event: str, callback: Callable[..., Any]) -> None:
+        """Register callback for an event."""
+        self._subscribers[event].append(callback)
+
+    def unsubscribe(self, event: str, callback: Callable[..., Any]) -> None:
+        """Remove callback for an event if present."""
+        if callback in self._subscribers.get(event, []):
+            self._subscribers[event].remove(callback)
+
+    def emit(self, event: str, *args: Any, **kwargs: Any) -> None:
+        """Send event to all registered listeners."""
+        for callback in list(self._subscribers.get(event, [])):
+            callback(*args, **kwargs)
+
+
+# Global instance used by the application
+event_bus = EventBus()

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,27 @@
+from modultool.event_bus import EventBus
+
+
+def test_subscribe_and_emit():
+    bus = EventBus()
+    received = []
+
+    def handler(value):
+        received.append(value)
+
+    bus.subscribe("test", handler)
+    bus.emit("test", 123)
+    assert received == [123]
+
+
+def test_unsubscribe():
+    bus = EventBus()
+    called = False
+
+    def handler():
+        nonlocal called
+        called = True
+
+    bus.subscribe("demo", handler)
+    bus.unsubscribe("demo", handler)
+    bus.emit("demo")
+    assert called is False

--- a/todo.txt
+++ b/todo.txt
@@ -39,6 +39,6 @@ Weitere Punkte stehen in der Datei OFFEN.md.
 - [x] T24 Backup Auto-Rotation
 - [x] T25 Fehlerdialog UI (Benutzertext + Details)
 - [x] T26 Settings Panel (Theme, FontScale)
-- [ ] T27 EventBus implementieren
+- [x] T27 EventBus implementieren
 - [ ] T28 Stats sammeln (module.open)
 - [ ] T29 Reset auf Werkzustand


### PR DESCRIPTION
## Summary
- implement EventBus publish/subscribe system
- expose global bus via `modultool`
- add unit tests for EventBus
- mark T27 as done in docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687de8596070832582a5928a27699ac1