### PR TITLE
Implement module open stats collection

### DIFF
--- a/OFFEN.md
+++ b/OFFEN.md
@@ -32,7 +32,7 @@ Format: - [ ] ID (Phase) Titel :: Ziel :: Akzeptanz
 - [x] T25 (P1) Fehlerdialog UI (Benutzertext + Details)
 - [x] T26 (P1) Settings Panel (Theme, FontScale)
 - [x] T27 (P1) EventBus implementieren
-- [ ] T28 (P1) Stats sammeln (module.open)
+- [x] T28 (P1) Stats sammeln (module.open)
 - [ ] T29 (P1) Reset auf Werkzustand
 - [ ] T30 (P1) Selfcheck periodisch
 

--- a/erledigt.txt
+++ b/erledigt.txt
@@ -25,3 +25,4 @@ T24 Backup Auto-Rotation :: 2025-07-21
 T25 Fehlerdialog UI :: 2025-07-21
 T26 Settings Panel :: 2025-07-21
 T27 EventBus implementiert :: 2025-07-21
+T28 Stats sammeln :: 2025-07-21

--- a/modultool/__init__.py
+++ b/modultool/__init__.py
@@ -3,6 +3,7 @@ from .selfcheck import run_selfcheck
 from .help_engine import register_help
 from .error_dialog import create_error_dialog
 from .event_bus import event_bus
+from .stats import stats
 
 run_selfcheck()
 
@@ -12,8 +13,9 @@ __all__ = [
     "register_help",
     "create_error_dialog",
     "event_bus",
+    "stats",
 ]
 
 run_selfcheck()
 
-__all__ = ["logger", "run_selfcheck", "register_help", "event_bus"]
+__all__ = ["logger", "run_selfcheck", "register_help", "event_bus", "stats"]

--- a/modultool/modules/base_module.py
+++ b/modultool/modules/base_module.py
@@ -1,7 +1,13 @@
+from ..event_bus import event_bus
+
+
 class BaseModule:
     """Base class for application modules."""
 
     name = "base"
+
+    def __init__(self) -> None:
+        event_bus.emit("module.open", self.name)
 
     def get_name(self) -> str:
         """Return the name of the module."""

--- a/modultool/modules/genres_module.py
+++ b/modultool/modules/genres_module.py
@@ -13,6 +13,7 @@ class GenresModule(BaseModule):
     name = "genres"
 
     def __init__(self, path: Path | None = None):
+        super().__init__()
         self.file = path or get_defaults_dir() / "genres.json"
         self.genres = load_json(self.file, [])
 

--- a/modultool/stats.py
+++ b/modultool/stats.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .config import get_data_dir
+from .error_handler import load_json
+from .event_bus import event_bus
+from .logger import logger
+
+
+class StatsManager:
+    """Collect simple statistics about module usage."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.file = path or get_data_dir() / "stats.json"
+        self.stats: dict[str, int] = load_json(self.file, {})
+        event_bus.subscribe("module.open", self.record_open)
+
+    def record_open(self, module: str) -> None:
+        """Increase counter for the given module name."""
+        self.stats[module] = self.stats.get(module, 0) + 1
+        with self.file.open("w", encoding="utf-8") as f:
+            json.dump(self.stats, f, indent=2, ensure_ascii=False)
+        logger.info("stats recorded: %s -> %s", module, self.stats[module])
+
+    def get_stats(self) -> dict[str, int]:
+        """Return a copy of the stats dictionary."""
+        return dict(self.stats)
+
+
+stats = StatsManager()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,13 @@
+import json
+from modultool.event_bus import event_bus
+from modultool.stats import StatsManager
+
+
+def test_stats_manager_records_module_open(tmp_path):
+    path = tmp_path / "stats.json"
+    manager = StatsManager(path=path)
+    event_bus.emit("module.open", "Demo")
+    event_bus.emit("module.open", "Demo")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["Demo"] == 2
+    event_bus.unsubscribe("module.open", manager.record_open)

--- a/todo.txt
+++ b/todo.txt
@@ -40,5 +40,5 @@ Weitere Punkte stehen in der Datei OFFEN.md.
 - [x] T25 Fehlerdialog UI (Benutzertext + Details)
 - [x] T26 Settings Panel (Theme, FontScale)
 - [x] T27 EventBus implementieren
-- [ ] T28 Stats sammeln (module.open)
+- [x] T28 Stats sammeln (module.open)
 - [ ] T29 Reset auf Werkzustand


### PR DESCRIPTION
## Summary
- add StatsManager subscribed to the event bus
- emit `module.open` event when BaseModule is initialised
- load stats manager on package import
- test stats recording
- update backlog and todo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_687dec717be88325826539cc6347881a