### PR TITLE
T29 reset

### DIFF
--- a/OFFEN.md
+++ b/OFFEN.md
@@ -33,7 +33,7 @@ Format: - [ ] ID (Phase) Titel :: Ziel :: Akzeptanz
 - [x] T26 (P1) Settings Panel (Theme, FontScale)
 - [x] T27 (P1) EventBus implementieren
 - [x] T28 (P1) Stats sammeln (module.open)
-- [ ] T29 (P1) Reset auf Werkzustand
+- [x] T29 (P1) Reset auf Werkzustand
 - [ ] T30 (P1) Selfcheck periodisch
 
 ## P2 Komfort

--- a/OFFEN.md
+++ b/OFFEN.md
@@ -38,7 +38,7 @@ Format: - [ ] ID (Phase) Titel :: Ziel :: Akzeptanz
 
 ## P2 Komfort
 - [x] T31 (P2) Import/Export ZIP
-- [ ] T32 (P2) Undo/Redo Basis (Genres)
+- [x] T32 (P2) Undo/Redo Basis (Genres)
 - [ ] T33 (P2) Kontext-Hilfe Panel (F1)
 - [ ] T34 (P2) Platzhalterkarte bei Modulfehler
 - [ ] T35 (P2) Onboarding Overlays

--- a/OFFEN.md
+++ b/OFFEN.md
@@ -37,7 +37,7 @@ Format: - [ ] ID (Phase) Titel :: Ziel :: Akzeptanz
 - [x] T30 (P1) Selfcheck periodisch
 
 ## P2 Komfort
-- [ ] T31 (P2) Import/Export ZIP
+- [x] T31 (P2) Import/Export ZIP
 - [ ] T32 (P2) Undo/Redo Basis (Genres)
 - [ ] T33 (P2) Kontext-Hilfe Panel (F1)
 - [ ] T34 (P2) Platzhalterkarte bei Modulfehler

--- a/OFFEN.md
+++ b/OFFEN.md
@@ -34,7 +34,7 @@ Format: - [ ] ID (Phase) Titel :: Ziel :: Akzeptanz
 - [x] T27 (P1) EventBus implementieren
 - [x] T28 (P1) Stats sammeln (module.open)
 - [x] T29 (P1) Reset auf Werkzustand
-- [ ] T30 (P1) Selfcheck periodisch
+- [x] T30 (P1) Selfcheck periodisch
 
 ## P2 Komfort
 - [ ] T31 (P2) Import/Export ZIP

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ echo '  "Metal"' >> data/defaults/genres.json
   python -m modultool.selfcheck
   ```
   Das Skript erstellt fehlende Dummy-Daten und schreibt eine Meldung ins Log.
+  Im Programm selbst wird alle 60 Minuten automatisch ein Selfcheck ausgeführt.
 * **Sidebar testen** (linke Navigationsleiste):
   ```bash
   python app.py

--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ echo '  "Metal"' >> data/defaults/genres.json
   python -m modultool.reset_manager
   ```
   Dadurch werden eigene Daten gelöscht und die Standardwerte über `selfcheck` neu angelegt.
+* **Daten exportieren** (komplette Sicherung als ZIP):
+  ```bash
+  python -m modultool.zip_manager export
+  ```
+  Die ZIP-Datei erscheint im Ordner `exports/`. Ein eigener Dateiname ist optional möglich.
+* **Daten importieren** (gesicherte ZIP wiederherstellen):
+  ```bash
+  python -m modultool.zip_manager import exports/data_YYYYMMDD_HHMMSS.zip
+  ```
+  Dabei werden bestehende Daten ersetzt.

--- a/README.md
+++ b/README.md
@@ -76,3 +76,13 @@ echo '  "Metal"' >> data/defaults/genres.json
   python -m modultool.zip_manager import exports/data_YYYYMMDD_HHMMSS.zip
   ```
   Dabei werden bestehende Daten ersetzt.
+* **Letzte Änderungen rückgängig machen** ("Undo" – vorherigen Zustand wiederherstellen):
+  ```bash
+  python - <<'PY'
+  from modultool.modules import GenresModule
+  module = GenresModule()
+  module.add_genre("Rock")
+  module.undo()
+  PY
+  ```
+  Mit `module.redo()` kannst du den Schritt erneut anwenden.

--- a/README.md
+++ b/README.md
@@ -60,3 +60,8 @@ echo '  "Metal"' >> data/defaults/genres.json
   ```
   Klicke auf die Knöpfe "Nav 1" bis "Nav 3". In der Logdatei siehst du dann den Eintrag "Nav 1 clicked" usw.
 
+* **Reset auf Werkzustand** ("factory reset" – stellt Standarddateien wieder her):
+  ```bash
+  python -m modultool.reset_manager
+  ```
+  Dadurch werden eigene Daten gelöscht und die Standardwerte über `selfcheck` neu angelegt.

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from modultool.settings_panel import SettingsDialog
 from modultool.logger import logger
 from modultool.theme_loader import apply_theme
 from modultool.help_engine import register_help
+from modultool.selfcheck import selfcheck_scheduler
 import sys
 
 
@@ -98,6 +99,8 @@ def main() -> int:
     apply_theme(app, "dark")
     window = MainWindow()
     window.show()
+    selfcheck_scheduler.start()
+    app.aboutToQuit.connect(selfcheck_scheduler.stop)
     return app.exec()
 
 

--- a/erledigt.txt
+++ b/erledigt.txt
@@ -27,3 +27,4 @@ T26 Settings Panel :: 2025-07-21
 T27 EventBus implementiert :: 2025-07-21
 T28 Stats sammeln :: 2025-07-21
 T29 Reset auf Werkzustand :: 2025-07-21
+T30 Selfcheck periodisch :: 2025-07-21

--- a/erledigt.txt
+++ b/erledigt.txt
@@ -28,3 +28,4 @@ T27 EventBus implementiert :: 2025-07-21
 T28 Stats sammeln :: 2025-07-21
 T29 Reset auf Werkzustand :: 2025-07-21
 T30 Selfcheck periodisch :: 2025-07-21
+T31 Import/Export ZIP :: 2025-07-21

--- a/erledigt.txt
+++ b/erledigt.txt
@@ -26,3 +26,4 @@ T25 Fehlerdialog UI :: 2025-07-21
 T26 Settings Panel :: 2025-07-21
 T27 EventBus implementiert :: 2025-07-21
 T28 Stats sammeln :: 2025-07-21
+T29 Reset auf Werkzustand :: 2025-07-21

--- a/erledigt.txt
+++ b/erledigt.txt
@@ -29,3 +29,4 @@ T28 Stats sammeln :: 2025-07-21
 T29 Reset auf Werkzustand :: 2025-07-21
 T30 Selfcheck periodisch :: 2025-07-21
 T31 Import/Export ZIP :: 2025-07-21
+T32 Undo/Redo Genres :: 2025-07-21

--- a/modultool/modules/genres_module.py
+++ b/modultool/modules/genres_module.py
@@ -5,6 +5,7 @@ from .base_module import BaseModule
 from ..autosave import autosave
 from ..config import get_defaults_dir
 from ..error_handler import load_json
+from ..undo_manager import UndoRedoManager
 
 
 class GenresModule(BaseModule):
@@ -16,11 +17,34 @@ class GenresModule(BaseModule):
         super().__init__()
         self.file = path or get_defaults_dir() / "genres.json"
         self.genres = load_json(self.file, [])
+        self._history = UndoRedoManager(depth=2)
 
     def add_genre(self, genre: str) -> None:
         """Add a genre to the internal list."""
+        self._history.record(self.genres)
         self.genres.append(genre)
         autosave.autosave(self)
+
+    def remove_genre(self, genre: str) -> None:
+        """Remove genre if present."""
+        if genre in self.genres:
+            self._history.record(self.genres)
+            self.genres.remove(genre)
+            autosave.autosave(self)
+
+    def undo(self) -> None:
+        """Revert the last change if possible."""
+        state = self._history.undo(self.genres)
+        if state != self.genres:
+            self.genres = state
+            autosave.autosave(self)
+
+    def redo(self) -> None:
+        """Reapply the last undone change if possible."""
+        state = self._history.redo(self.genres)
+        if state != self.genres:
+            self.genres = state
+            autosave.autosave(self)
 
     def save(self) -> None:
         """Write genres to disk."""

--- a/modultool/reset_manager.py
+++ b/modultool/reset_manager.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import shutil
+
+from .config import get_data_dir
+from .logger import logger
+from .selfcheck import run_selfcheck
+
+
+class ResetManager:
+    """Remove user data and recreate default files."""
+
+    def reset(self) -> None:
+        data_dir = get_data_dir()
+        for item in data_dir.iterdir():
+            if item.name == "themes":
+                continue
+            if item.is_dir():
+                shutil.rmtree(item, ignore_errors=True)
+            else:
+                item.unlink(missing_ok=True)
+        run_selfcheck()
+        logger.info("factory reset executed")
+
+
+reset_manager = ResetManager()
+
+
+if __name__ == "__main__":
+    reset_manager.reset()

--- a/modultool/selfcheck.py
+++ b/modultool/selfcheck.py
@@ -1,4 +1,5 @@
 import json
+import threading
 
 from .config import get_defaults_dir
 from .logger import logger
@@ -33,3 +34,34 @@ def run_selfcheck() -> None:
         logger.info("defaults: quotes.json erzeugt")
 
     logger.info("Selfcheck abgeschlossen")
+
+
+class SelfcheckScheduler:
+    """Run selfcheck periodically in a background timer."""
+
+    def __init__(self, interval: int = 3600) -> None:
+        self.interval = interval
+        self._timer: threading.Timer | None = None
+
+    def start(self) -> None:
+        """Begin periodic execution of ``run_selfcheck``."""
+        self.stop()
+        self._schedule()
+
+    def _schedule(self) -> None:
+        self._timer = threading.Timer(self.interval, self._run)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def _run(self) -> None:
+        run_selfcheck()
+        self._schedule()
+
+    def stop(self) -> None:
+        """Cancel the periodic execution."""
+        if self._timer:
+            self._timer.cancel()
+            self._timer = None
+
+
+selfcheck_scheduler = SelfcheckScheduler()

--- a/modultool/undo_manager.py
+++ b/modultool/undo_manager.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+
+class UndoRedoManager:
+    """Track history for undo and redo with limited depth."""
+
+    def __init__(self, depth: int = 2) -> None:
+        self.depth = depth
+        self._undo: list[list[str]] = []
+        self._redo: list[list[str]] = []
+
+    def record(self, state: list[str]) -> None:
+        """Store a copy of the current state for undo."""
+        self._undo.append(list(state))
+        if len(self._undo) > self.depth:
+            self._undo.pop(0)
+        self._redo.clear()
+
+    def undo(self, current_state: list[str]) -> list[str]:
+        """Return previous state if available."""
+        if not self._undo:
+            return current_state
+        self._redo.append(list(current_state))
+        if len(self._redo) > self.depth:
+            self._redo.pop(0)
+        return self._undo.pop()
+
+    def redo(self, current_state: list[str]) -> list[str]:
+        """Return next state if available."""
+        if not self._redo:
+            return current_state
+        self._undo.append(list(current_state))
+        if len(self._undo) > self.depth:
+            self._undo.pop(0)
+        return self._redo.pop()

--- a/modultool/zip_manager.py
+++ b/modultool/zip_manager.py
@@ -1,0 +1,52 @@
+import shutil
+from datetime import datetime
+from pathlib import Path
+from zipfile import ZipFile
+
+from .config import get_data_dir, get_root_dir
+from .logger import logger
+
+
+class ZipManager:
+    """Export and import the data directory as a zip archive."""
+
+    def export_zip(self, dest: Path | None = None) -> Path:
+        data_dir = get_data_dir()
+        exports_dir = get_root_dir() / "exports"
+        exports_dir.mkdir(exist_ok=True)
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        dest = dest or exports_dir / f"data_{stamp}.zip"
+        with ZipFile(dest, "w") as zf:
+            for path in data_dir.rglob("*"):
+                if path.is_file():
+                    zf.write(path, path.relative_to(data_dir))
+        logger.info("export zip created: %s", dest.name)
+        return dest
+
+    def import_zip(self, zip_path: Path) -> None:
+        data_dir = get_data_dir()
+        if data_dir.exists():
+            shutil.rmtree(data_dir)
+        with ZipFile(zip_path, "r") as zf:
+            zf.extractall(data_dir)
+        logger.info("import zip restored from: %s", zip_path.name)
+
+
+zip_manager = ZipManager()
+
+
+if __name__ == "__main__":
+    import sys
+
+    action = sys.argv[1] if len(sys.argv) > 1 else "export"
+    file_arg = Path(sys.argv[2]) if len(sys.argv) > 2 else None
+
+    if action == "export":
+        result = zip_manager.export_zip(file_arg)
+        print(result)
+    elif action == "import" and file_arg:
+        zip_manager.import_zip(file_arg)
+    else:
+        print(
+            "Usage: python -m modultool.zip_manager [export [dest.zip]|import <src.zip>]"
+        )

--- a/tests/test_genres_module.py
+++ b/tests/test_genres_module.py
@@ -11,3 +11,15 @@ def test_add_genre(tmp_path):
     assert "Electro" in module.get_genres()
     data = json.loads(genres_file.read_text(encoding="utf-8"))
     assert "Electro" in data
+
+
+def test_undo_redo(tmp_path):
+    genres_file = tmp_path / "genres.json"
+    genres_file.write_text(json.dumps(["Pop"]), encoding="utf-8")
+    module = GenresModule(path=genres_file)
+    module.add_genre("Electro")
+    assert module.get_genres() == ["Pop", "Electro"]
+    module.undo()
+    assert module.get_genres() == ["Pop"]
+    module.redo()
+    assert module.get_genres() == ["Pop", "Electro"]

--- a/tests/test_reset_manager.py
+++ b/tests/test_reset_manager.py
@@ -1,0 +1,28 @@
+import json
+import importlib
+
+from modultool import config, reset_manager, selfcheck
+
+
+def test_reset_recreates_defaults(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    defaults_dir = data_dir / "defaults"
+    defaults_dir.mkdir(parents=True)
+    themes_dir = data_dir / "themes"
+    themes_dir.mkdir()
+
+    (data_dir / "module_order.json").write_text("[]", encoding="utf-8")
+    genres_file = defaults_dir / "genres.json"
+    genres_file.write_text(json.dumps(["Custom"]), encoding="utf-8")
+
+    monkeypatch.setattr(config, "get_data_dir", lambda: data_dir)
+    monkeypatch.setattr(selfcheck, "get_defaults_dir", lambda: defaults_dir)
+
+    importlib.reload(reset_manager)
+
+    reset_manager.reset_manager.reset()
+
+    assert not (data_dir / "module_order.json").exists()
+    with genres_file.open(encoding="utf-8") as f:
+        genres = json.load(f)
+    assert genres == selfcheck.DEFAULT_GENRES

--- a/tests/test_selfcheck_scheduler.py
+++ b/tests/test_selfcheck_scheduler.py
@@ -1,0 +1,12 @@
+import time
+import modultool.selfcheck as selfcheck
+
+
+def test_scheduler_runs(monkeypatch):
+    called = []
+    monkeypatch.setattr(selfcheck, "run_selfcheck", lambda: called.append(True))
+    scheduler = selfcheck.SelfcheckScheduler(interval=0.01)
+    scheduler.start()
+    time.sleep(0.03)
+    scheduler.stop()
+    assert called

--- a/tests/test_zip_manager.py
+++ b/tests/test_zip_manager.py
@@ -1,0 +1,22 @@
+import importlib
+
+from modultool import config
+
+
+def test_export_import_zip(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    sample = data_dir / "sample.txt"
+    sample.write_text("hello", encoding="utf-8")
+
+    monkeypatch.setattr(config, "get_data_dir", lambda: data_dir)
+    monkeypatch.setattr(config, "get_root_dir", lambda: tmp_path)
+
+    module = importlib.import_module("modultool.zip_manager")
+    importlib.reload(module)
+
+    dest = module.zip_manager.export_zip()
+    sample.unlink()
+
+    module.zip_manager.import_zip(dest)
+    assert (data_dir / "sample.txt").read_text(encoding="utf-8") == "hello"

--- a/todo.txt
+++ b/todo.txt
@@ -42,3 +42,4 @@ Weitere Punkte stehen in der Datei OFFEN.md.
 - [x] T27 EventBus implementieren
 - [x] T28 Stats sammeln (module.open)
 - [x] T29 Reset auf Werkzustand
+- [x] T30 Selfcheck periodisch

--- a/todo.txt
+++ b/todo.txt
@@ -41,4 +41,4 @@ Weitere Punkte stehen in der Datei OFFEN.md.
 - [x] T26 Settings Panel (Theme, FontScale)
 - [x] T27 EventBus implementieren
 - [x] T28 Stats sammeln (module.open)
-- [ ] T29 Reset auf Werkzustand
+- [x] T29 Reset auf Werkzustand

--- a/todo.txt
+++ b/todo.txt
@@ -43,3 +43,8 @@ Weitere Punkte stehen in der Datei OFFEN.md.
 - [x] T28 Stats sammeln (module.open)
 - [x] T29 Reset auf Werkzustand
 - [x] T30 Selfcheck periodisch
+- [x] T31 Import/Export ZIP
+- [ ] T32 Undo/Redo Basis (Genres)
+- [ ] T33 Kontext-Hilfe Panel (F1)
+- [ ] T34 Platzhalterkarte bei Modulfehler
+- [ ] T35 Onboarding Overlays

--- a/todo.txt
+++ b/todo.txt
@@ -44,7 +44,7 @@ Weitere Punkte stehen in der Datei OFFEN.md.
 - [x] T29 Reset auf Werkzustand
 - [x] T30 Selfcheck periodisch
 - [x] T31 Import/Export ZIP
-- [ ] T32 Undo/Redo Basis (Genres)
+- [x] T32 Undo/Redo Basis (Genres)
 - [ ] T33 Kontext-Hilfe Panel (F1)
 - [ ] T34 Platzhalterkarte bei Modulfehler
 - [ ] T35 Onboarding Overlays


### PR DESCRIPTION
## Summary
- add reset manager to wipe data and recreate defaults
- document factory reset usage in README
- mark T29 done in OFFEN and todo
- record T29 completion in erledigt list
- test reset manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687def2100a88325937ff5dcaadf9a33