### PR TITLE
Implement placeholder module fallback

### DIFF
--- a/OFFEN.md
+++ b/OFFEN.md
@@ -40,7 +40,7 @@ Format: - [ ] ID (Phase) Titel :: Ziel :: Akzeptanz
 - [x] T31 (P2) Import/Export ZIP
 - [x] T32 (P2) Undo/Redo Basis (Genres)
 - [x] T33 (P2) Kontext-Hilfe Panel (F1)
-- [ ] T34 (P2) Platzhalterkarte bei Modulfehler
+- [x] T34 (P2) Platzhalterkarte bei Modulfehler
 - [ ] T35 (P2) Onboarding Overlays
 
 ## S (Stretch)

--- a/erledigt.txt
+++ b/erledigt.txt
@@ -31,3 +31,4 @@ T30 Selfcheck periodisch :: 2025-07-21
 T31 Import/Export ZIP :: 2025-07-21
 T32 Undo/Redo Genres :: 2025-07-21
 T33 Kontext-Hilfe Panel :: 2025-07-21
+T34 Platzhalterkarte Modulfehler :: 2025-07-22

--- a/modultool/help_engine.py
+++ b/modultool/help_engine.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 from PySide6.QtWidgets import (
     QDialog,
-    QLabel,
     QPushButton,
     QTextEdit,
     QVBoxLayout,
     QWidget,
 )
 
+from .logger import logger
+
 
 _HELP_REGISTRY: dict[str, str] = {}
-
-from .logger import logger
 
 
 def register_help(widget: QWidget, text: str) -> None:

--- a/modultool/module_loader.py
+++ b/modultool/module_loader.py
@@ -2,6 +2,23 @@ import importlib
 import pkgutil
 
 from .modules import BaseModule
+from .logger import logger
+
+
+def _create_placeholder(name: str, exc: Exception) -> type[BaseModule]:
+    """Return a placeholder module class describing the import error."""
+
+    class Placeholder(BaseModule):
+        """Dummy module used when a real one fails to import."""
+
+        error = str(exc)
+
+        def start(self) -> None:  # pragma: no cover - just logs
+            logger.warning("placeholder for %s: %s", name, self.error)
+
+    Placeholder.__name__ = f"{name}_placeholder"
+    Placeholder.name = name
+    return Placeholder
 
 
 def discover_modules() -> dict[str, type[BaseModule]]:
@@ -11,7 +28,12 @@ def discover_modules() -> dict[str, type[BaseModule]]:
     for info in pkgutil.iter_modules(package.__path__):
         if info.name == "base_module":
             continue
-        module = importlib.import_module(f"modultool.modules.{info.name}")
+        try:
+            module = importlib.import_module(f"modultool.modules.{info.name}")
+        except Exception as exc:  # broad so broken modules still listed
+            modules[info.name] = _create_placeholder(info.name, exc)
+            logger.error("failed to load module %s: %s", info.name, exc)
+            continue
         for attr in dir(module):
             obj = getattr(module, attr)
             if (

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -4,3 +4,32 @@ from modultool import module_loader
 def test_discover_modules_returns_genres():
     modules = module_loader.discover_modules()
     assert "GenresModule" in modules
+
+
+def test_discover_modules_handles_import_error(monkeypatch):
+    orig_iter = module_loader.pkgutil.iter_modules
+
+    def fake_iter_modules(path):
+        yield from orig_iter(path)
+
+        class Info:
+            name = "broken"
+
+        yield Info()
+
+    monkeypatch.setattr(module_loader.pkgutil, "iter_modules", fake_iter_modules)
+
+    orig_import = module_loader.importlib.import_module
+
+    def fake_import(name, package=None):
+        if name == "modultool.modules.broken":
+            raise RuntimeError("boom")
+        return orig_import(name, package=package)
+
+    monkeypatch.setattr(module_loader.importlib, "import_module", fake_import)
+
+    modules = module_loader.discover_modules()
+    placeholder = modules.get("broken")
+    assert placeholder is not None
+    inst = placeholder()
+    assert hasattr(inst, "error") and "boom" in inst.error

--- a/todo.txt
+++ b/todo.txt
@@ -46,5 +46,5 @@ Weitere Punkte stehen in der Datei OFFEN.md.
 - [x] T31 Import/Export ZIP
 - [x] T32 Undo/Redo Basis (Genres)
 - [x] T33 Kontext-Hilfe Panel (F1)
-- [ ] T34 Platzhalterkarte bei Modulfehler
+- [x] T34 Platzhalterkarte bei Modulfehler
 - [ ] T35 Onboarding Overlays


### PR DESCRIPTION
## Summary
- show placeholder module when discovery import fails
- test error handling for module discovery
- keep help engine lint-clean
- update backlog and todo lists
- record task completion

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fea28a0b08325bc317b37d5da82a6