### PR TITLE
TS2 manifest checker

### DIFF
--- a/OFFEN.md
+++ b/OFFEN.md
@@ -45,7 +45,7 @@ Format: - [ ] ID (Phase) Titel :: Ziel :: Akzeptanz
 
 ## S (Stretch)
 - [x] TS1 (S) Sandbox Mode
-- [ ] TS2 (S) Manifest Permissions Prüfer
+- [x] TS2 (S) Manifest Permissions Prüfer
 - [ ] TS3 (S) AppImage Build Script
 
 ## BLOCKIERT

--- a/README.md
+++ b/README.md
@@ -108,3 +108,12 @@ echo '  "Metal"' >> data/defaults/genres.json
   from modultool import enable_sandbox
   enable_sandbox()
   ```
+* **Manifest prüfen** ("permissions" = Berechtigungen):
+  Die Datei `manifest.json` beschreibt, was die App darf. Mit dem
+  kleinen Prüfer kontrollierst du diese Rechte:
+  ```bash
+  python -m modultool.permissions_checker
+  ```
+  Bei Erfolg erscheint `Manifest OK`. Unbekannte Rechte meldet der
+  Prüfer im Log (`logs/modultool.log`). Erlaubt sind `read`, `write`
+  und `network`.

--- a/erledigt.txt
+++ b/erledigt.txt
@@ -34,3 +34,4 @@ T33 Kontext-Hilfe Panel :: 2025-07-21
 T34 Platzhalterkarte Modulfehler :: 2025-07-22
 T35 Onboarding Overlays :: 2025-07-22
 TS1 Sandbox Mode :: 2025-07-22
+TS2 Manifest Permissions Prüfer :: 2025-07-22

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,5 @@
+{
+  "name": "ModulTool",
+  "version": "0.1.0",
+  "permissions": ["read", "write"]
+}

--- a/modultool/permissions_checker.py
+++ b/modultool/permissions_checker.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+from .logger import logger
+from .config import get_root_dir
+
+ALLOWED_PERMISSIONS = {"read", "write", "network"}
+
+
+def check_manifest(manifest_path: Path | None = None) -> bool:
+    """Validate permissions in the manifest file."""
+    if manifest_path is None:
+        manifest_path = get_root_dir() / "manifest.json"
+
+    if not manifest_path.exists():
+        logger.error("manifest fehlt: %s", manifest_path)
+        return False
+
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        logger.error("manifest unlesbar: %s", exc)
+        return False
+
+    perms = data.get("permissions", [])
+    invalid = [p for p in perms if p not in ALLOWED_PERMISSIONS]
+    if invalid:
+        logger.error("unbekannte Berechtigungen: %s", ", ".join(invalid))
+        return False
+
+    logger.info("permissions ok: %s", ", ".join(perms))
+    return True
+
+
+if __name__ == "__main__":  # pragma: no cover - cli usage
+    ok = check_manifest()
+    print("Manifest OK" if ok else "Manifest fehlerhaft")

--- a/tests/test_permissions_checker.py
+++ b/tests/test_permissions_checker.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+import modultool.permissions_checker as pc
+
+
+def test_check_manifest_ok(tmp_path, monkeypatch):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"permissions": ["read", "write"]}), encoding="utf-8"
+    )
+    monkeypatch.setattr(pc, "get_root_dir", lambda: tmp_path)
+    assert pc.check_manifest()
+
+
+def test_check_manifest_invalid(tmp_path, monkeypatch):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"permissions": ["delete"]}), encoding="utf-8"
+    )
+    monkeypatch.setattr(pc, "get_root_dir", lambda: tmp_path)
+    assert not pc.check_manifest()

--- a/todo.txt
+++ b/todo.txt
@@ -49,3 +49,4 @@ Weitere Punkte stehen in der Datei OFFEN.md.
 - [x] T34 Platzhalterkarte bei Modulfehler
 - [x] T35 Onboarding Overlays
 - [x] TS1 Sandbox Mode
+- [x] TS2 Manifest Permissions Prüfer


### PR DESCRIPTION
## Summary
- implement permissions checker for manifest.json
- document usage in README
- mark TS2 as done in backlog and todo list
- record completion in erledigt.txt
- add tests for the new checker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff50cf98c83259f8045cd6e8fc4fd